### PR TITLE
Release v2.0.0 — multi-turn, response decoder, model constants, JSON fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27.2"
-          gleam-version: "1.6.0"
+          gleam-version: "1.16.0"
           rebar3-version: "3"
       - run: gleam deps download
       - run: gleam test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: test
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 
@@ -11,13 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.0.2"
-          gleam-version: "1.0.0"
+          otp-version: "27.2"
+          gleam-version: "1.6.0"
           rebar3-version: "3"
-          elixir-version: "1.15.4"
       - run: gleam deps download
       - run: gleam test
-      - run: gleam format --check src
+      - run: gleam format --check src test

--- a/README.md
+++ b/README.md
@@ -4,31 +4,199 @@
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/gloq/)
 [![test](https://github.com/AryaanSheth/gloq/actions/workflows/test.yml/badge.svg)](https://github.com/AryaanSheth/gloq/actions/workflows/test.yml)
 
-> [!Note]
-> Library is in its very early stages      
-> Feel free to create PR's and Issues
+A Gleam library for the [GroqCloud](https://console.groq.com) inference API.
+Build type-safe chat completion requests using a fluent builder, then send
+them with any HTTP client you choose.
 
 ```sh
 gleam add gloq
 ```
+
+After adding, run `gleam deps download` if prompted.
+
+---
+
+## Quick start
+
 ```gleam
+import gleam/httpc
 import gleam/io
 import gloq
+import gloq/response
 
 pub fn main() {
-  let key = "abc123"
+  let assert Ok(res) =
+    gloq.default_groq_request()
+    |> gloq.with_key("YOUR_API_KEY")
+    |> gloq.with_context("What is the capital of France?")
+    |> gloq.build()
+    |> httpc.send()
 
-  let req = 
-    default_groq_request()
-    |> with_key(key)
-    |> with_user("user")
-    |> with_context("Hello, how are you?")
-    |> with_model("llama3-8b-8192")
-    |> build()
-
-  io.println(req.body)
-
+  let assert Ok(completion) = response.decode(res.body)
+  io.println(response.content(completion))
 }
 ```
 
-Further documentation can be found at <https://hex.pm/packages/gloq>.
+---
+
+## Choosing a model
+
+Import constants from `gloq/models` instead of using raw strings:
+
+```gleam
+import gloq
+import gloq/models
+
+gloq.default_groq_request()
+|> gloq.with_key(api_key)
+|> gloq.with_model(models.llama_3_3_70b_versatile)
+|> gloq.with_context("Explain monads in one sentence.")
+|> gloq.build()
+```
+
+Available model constants (see [`gloq/models`](src/gloq/models.gleam) for the full list):
+
+| Constant | Model ID |
+|---|---|
+| `models.llama_3_3_70b_versatile` | `llama-3.3-70b-versatile` |
+| `models.llama_3_1_8b_instant` | `llama-3.1-8b-instant` *(default)* |
+| `models.llama_3_1_70b_versatile` | `llama-3.1-70b-versatile` |
+| `models.mixtral_8x7b_32768` | `mixtral-8x7b-32768` |
+| `models.gemma2_9b_it` | `gemma2-9b-it` |
+| `models.deepseek_r1_distill_llama_70b` | `deepseek-r1-distill-llama-70b` |
+
+---
+
+## Multi-turn conversations
+
+Use `add_user_message`, `add_assistant_message`, and `with_system_prompt` to
+build a full conversation thread:
+
+```gleam
+gloq.default_groq_request()
+|> gloq.with_key(api_key)
+|> gloq.with_model(models.llama_3_3_70b_versatile)
+|> gloq.with_system_prompt("You are a terse assistant. Reply in one sentence.")
+|> gloq.add_user_message("What is Gleam?")
+|> gloq.add_assistant_message("Gleam is a type-safe language that runs on the Erlang VM.")
+|> gloq.add_user_message("What is its mascot?")
+|> gloq.build()
+```
+
+---
+
+## Structured JSON output
+
+Pass `"json_object"` to `with_response_format` and instruct the model to
+return JSON in the system prompt:
+
+```gleam
+gloq.default_groq_request()
+|> gloq.with_key(api_key)
+|> gloq.with_system_prompt("Respond only with valid JSON.")
+|> gloq.with_context("Give me a person with a name and age.")
+|> gloq.with_response_format("json_object")
+|> gloq.build()
+```
+
+---
+
+## Decoding responses
+
+`gloq/response` provides types and a decoder for the API response:
+
+```gleam
+import gloq/response
+
+case response.decode(res.body) {
+  Ok(completion) -> {
+    io.println(response.content(completion))
+    // completion.usage.total_tokens
+    // completion.model
+    // response.all_contents(completion)
+  }
+  Error(_) ->
+    // Try decoding an API error instead
+    case response.decode_error(res.body) {
+      Ok(err) -> io.println(err.message)
+      Error(_) -> io.println("Unknown error")
+    }
+}
+```
+
+---
+
+## All builder options
+
+| Function | Type | Default | Description |
+|---|---|---|---|
+| `with_key` | `String` | `""` | GroqCloud API key |
+| `with_model` | `String` | `"llama-3.1-8b-instant"` | Model to use |
+| `with_context` | `String` | `""` | Single-turn prompt |
+| `with_user` | `String` | `"user"` | Role label for single-turn message |
+| `with_system_prompt` | `String` | — | System message prepended to every request |
+| `add_user_message` | `String` | — | Append a user turn |
+| `add_assistant_message` | `String` | — | Append an assistant turn |
+| `with_messages` | `List(Message)` | `[]` | Replace the full message list |
+| `with_temperature` | `Float` | `1.0` | 0–2, higher = more random |
+| `with_top_p` | `Float` | `1.0` | Nucleus sampling threshold |
+| `with_max_tokens` | `Int` | *(model default)* | Max tokens to generate |
+| `with_frequency_penalty` | `Float` | `0.0` | -2.0–2.0, penalises repetition |
+| `with_presence_penalty` | `Float` | `0.0` | -2.0–2.0, encourages new topics |
+| `with_seed` | `Int` | — | Enables deterministic sampling |
+| `with_stop` | `String` | — | Stop sequence |
+| `with_stream` | `Bool` | `False` | Enable SSE streaming |
+| `with_n` | `Int` | `1` | Number of completions (only 1 supported) |
+| `with_logprobs` | `Bool` | — | Return token log probabilities |
+| `with_parallel_tool_calls` | `Bool` | `True` | Allow parallel tool calls |
+| `with_response_format` | `String` | — | `"json_object"` for structured output |
+
+---
+
+## Model listing
+
+```gleam
+import gleam/httpc
+import gloq
+
+// List all available models
+let req = gloq.list_models(api_key)
+
+// Get a specific model's details
+let req = gloq.get_model(api_key, "llama-3.1-8b-instant")
+```
+
+---
+
+## Migration from v1.x
+
+### Changed defaults
+- Default model changed from `"llama3-8b-8192"` to `"llama-3.1-8b-instant"`.
+  Set the model explicitly if you need the old default.
+
+### `new_groq_request` behaviour
+- `new_groq_request()` now returns `None` for all optional fields instead of
+  inheriting defaults. If you relied on `new_groq_request()` giving you
+  temperature `1.0` etc., switch to `default_groq_request()`.
+
+### JSON body fix
+- Optional fields that are `None` are no longer serialised. Previously `seed: None`
+  would send `"seed": 0` to the API; now it is omitted entirely.
+
+### New fields on `GroqRequestBuilder`
+- Three new fields were added: `system_prompt`, `messages`, `response_format`.
+  If you construct `GroqRequestBuilder(...)` directly (rather than using the
+  builder functions) you must add these fields. Recommended: use
+  `default_groq_request()` or `new_groq_request()` as a base.
+
+### Removed dependencies
+- `dot_env`, `dotenv`, and `gleam_httpc` were removed from the package
+  dependencies (they were never used). Run `gleam deps download` after updating.
+
+### `send` is still present but deprecated
+- `send/1` still works but remains deprecated. Use `build/1` with your own
+  HTTP client.
+
+---
+
+Further documentation at <https://hexdocs.pm/gloq>.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,26 +1,17 @@
 name = "gloq"
-version = "1.4.2"
+version = "2.0.0"
 
-# Fill out these fields if you intend to generate HTML documentation or publish
-# your project to the Hex package manager.
-#
 description = "Gleam API Wrapper to Interface with the GroqCloud API"
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "AryaanSheth", repo = "gloq" }
-gleam = ">= 0.32.0"
-# links = [{ title = "Website", href = "https://gleam.run" }]
-#
-# For a full reference of all the available options, you can have a look at
-# https://gleam.run/writing-gleam/gleam-toml/. 
+gleam = ">= 1.0.0"
+links = [{ title = "GroqCloud Console", href = "https://console.groq.com" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = "~> 1.0"
 gleam_http = ">= 3.6.0 and < 4.0.0"
 gleam_json = ">= 2.0.0 and < 3.0.0"
-gleam_httpc = ">= 2.2.0 and < 3.0.0"
 gleam_hackney = ">= 1.2.0 and < 2.0.0"
-dot_env = ">= 1.1.0 and < 2.0.0"
-dotenv = ">= 3.1.0 and < 4.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -4,13 +4,13 @@ version = "2.0.0"
 description = "Gleam API Wrapper to Interface with the GroqCloud API"
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "AryaanSheth", repo = "gloq" }
-gleam = ">= 1.0.0"
+gleam = ">= 1.5.0"
 links = [{ title = "GroqCloud Console", href = "https://console.groq.com" }]
 
 [dependencies]
 gleam_stdlib = "~> 1.0"
-gleam_http = ">= 3.6.0 and < 4.0.0"
-gleam_json = ">= 2.0.0 and < 3.0.0"
+gleam_http = ">= 4.0.0 and < 5.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
 gleam_hackney = ">= 1.2.0 and < 2.0.0"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,8 +4,8 @@
 packages = [
   { name = "certifi", version = "2.15.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "B147ED22CE71D72EAFDAD94F055165C1C182F61A2FF49DF28BCC71D1D5B94A60" },
   { name = "gleam_hackney", version = "1.3.3", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "03B4125E5E6DFD6BC20CC1FAD0D35B8474D9515DFDFFB69255EFE6D7B49BEB07" },
-  { name = "gleam_http", version = "3.7.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8A70D2F70BB7CFEB5DF048A2183FFBA91AF6D4CF5798504841744A16999E33D2" },
-  { name = "gleam_json", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "C55C5C2B318533A8072D221C5E06E5A75711C129E420DD1CE463342106012E5D" },
+  { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
+  { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_stdlib", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0C5506589DF4C63DF5D6FFBB834562D6865C6C2AEE0019D7B37886BD6D128141" },
   { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
   { name = "hackney", version = "1.25.0", build_tools = ["rebar3"], requirements = ["certifi", "idna", "metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "7209BFD75FD1F42467211FF8F59EA74D6F2A9E81CBCEE95A56711EE79FD6B1D4" },
@@ -19,7 +19,7 @@ packages = [
 
 [requirements]
 gleam_hackney = { version = ">= 1.2.0 and < 2.0.0" }
-gleam_http = { version = ">= 3.6.0 and < 4.0.0" }
-gleam_json = { version = ">= 2.0.0 and < 3.0.0" }
+gleam_http = { version = ">= 4.0.0 and < 5.0.0" }
+gleam_json = { version = ">= 3.0.0 and < 4.0.0" }
 gleam_stdlib = { version = "~> 1.0" }
 gleeunit = { version = "~> 1.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,32 +2,24 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "certifi", version = "2.12.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "EE68D85DF22E554040CDB4BE100F33873AC6051387BAF6A8F6CE82272340FF1C" },
-  { name = "dot_env", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "simplifile"], otp_app = "dot_env", source = "hex", outer_checksum = "C791917FDA9B75AF26923C17CE2BC15469E1B2C79D9D9F3D0882B3C531EE6337" },
-  { name = "dotenv", version = "3.1.0", build_tools = ["mix"], requirements = [], otp_app = "dotenv", source = "hex", outer_checksum = "01BED84D21BEDD8739AEBAD16489A3CE12D19C2D59AF87377DA65EBB361980D3" },
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_hackney", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "066B1A55D37DBD61CC72A1C4EDE43C6015B1797FAF3818C16FE476534C7B6505" },
-  { name = "gleam_http", version = "3.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8C07DF9DF8CC7F054C650839A51C30A7D3C26482AC241C899C1CEA86B22DBE51" },
-  { name = "gleam_httpc", version = "2.2.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "CF76C71002DEECF6DC5D9CA83D962728FAE166B57926BE442D827004D3C7DF1B" },
-  { name = "gleam_json", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB10B0E7BF44282FB25162F1A24C1A025F6B93E777CCF238C4017E4EEF2CDE97" },
-  { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "hackney", version = "1.20.1", build_tools = ["rebar3"], requirements = ["certifi", "idna", "metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "FE9094E5F1A2A2C0A7D10918FEE36BFEC0EC2A979994CFF8CFE8058CD9AF38E3" },
+  { name = "certifi", version = "2.15.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "B147ED22CE71D72EAFDAD94F055165C1C182F61A2FF49DF28BCC71D1D5B94A60" },
+  { name = "gleam_hackney", version = "1.3.3", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "03B4125E5E6DFD6BC20CC1FAD0D35B8474D9515DFDFFB69255EFE6D7B49BEB07" },
+  { name = "gleam_http", version = "3.7.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8A70D2F70BB7CFEB5DF048A2183FFBA91AF6D4CF5798504841744A16999E33D2" },
+  { name = "gleam_json", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "C55C5C2B318533A8072D221C5E06E5A75711C129E420DD1CE463342106012E5D" },
+  { name = "gleam_stdlib", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0C5506589DF4C63DF5D6FFBB834562D6865C6C2AEE0019D7B37886BD6D128141" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "hackney", version = "1.25.0", build_tools = ["rebar3"], requirements = ["certifi", "idna", "metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "7209BFD75FD1F42467211FF8F59EA74D6F2A9E81CBCEE95A56711EE79FD6B1D4" },
   { name = "idna", version = "6.1.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat"], otp_app = "idna", source = "hex", outer_checksum = "92376EB7894412ED19AC475E4A86F7B413C1B9FBB5BD16DCCD57934157944CEA" },
   { name = "metrics", version = "1.0.1", build_tools = ["rebar3"], requirements = [], otp_app = "metrics", source = "hex", outer_checksum = "69B09ADDDC4F74A40716AE54D140F93BEB0FB8978D8636EADED0C31B6F099F16" },
-  { name = "mimerl", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "A1E15A50D1887217DE95F0B9B0793E32853F7C258A5CD227650889B38839FE9D" },
+  { name = "mimerl", version = "1.5.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "DB648CE065BAE14EA84CA8B5DD123F42F49417CEF693541110BF6F9E9BE9ECC4" },
   { name = "parse_trans", version = "3.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "parse_trans", source = "hex", outer_checksum = "620A406CE75DADA827B82E453C19CF06776BE266F5A67CFF34E1EF2CBB60E49A" },
-  { name = "simplifile", version = "2.1.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "BDD04F5D31D6D34E2EDFAEF0B68A6297AEC939888C3BFCE61133DE13857F6DA2" },
   { name = "ssl_verify_fun", version = "1.1.7", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8" },
-  { name = "unicode_util_compat", version = "0.7.0", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "25EEE6D67DF61960CF6A794239566599B09E17E668D3700247BC498638152521" },
+  { name = "unicode_util_compat", version = "0.7.1", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "B3A917854CE3AE233619744AD1E0102E05673136776FB2FA76234F3E03B23642" },
 ]
 
 [requirements]
-dot_env = { version = ">= 1.1.0 and < 2.0.0" }
-dotenv = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_hackney = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_http = { version = ">= 3.6.0 and < 4.0.0" }
-gleam_httpc = { version = ">= 2.2.0 and < 3.0.0" }
 gleam_json = { version = ">= 2.0.0 and < 3.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_stdlib = { version = "~> 1.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/gloq.gleam
+++ b/src/gloq.gleam
@@ -1,9 +1,20 @@
 import gleam/hackney
 import gleam/http
-import gleam/http/request
-import gleam/json
+import gleam/http/request.{type Request}
+import gleam/json.{type Json}
+import gleam/list
 import gleam/option.{type Option, None, Some}
 
+/// A single message in a conversation, used for multi-turn requests.
+pub type Message {
+  Message(role: String, content: String)
+}
+
+/// Builder for a GroqCloud chat completion request.
+///
+/// Construct one with `default_groq_request/0` or `new_groq_request/0`,
+/// chain `with_*` setters, then call `build/1` to get an HTTP request
+/// you can send with any client (e.g. `gleam_httpc` or `gleam_hackney`).
 pub type GroqRequestBuilder {
   GroqRequestBuilder(
     key: String,
@@ -21,19 +32,22 @@ pub type GroqRequestBuilder {
     stream: Option(Bool),
     temperature: Option(Float),
     top_p: Option(Float),
+    system_prompt: Option(String),
+    messages: List(Message),
+    response_format: Option(String),
   )
 }
 
-/// Creates a new GroqRequestBuilder with default model and user values.
-/// Uses the default model `llama3-8b-8192` and user role `user`.
+/// Creates a new `GroqRequestBuilder` with sensible defaults.
+/// Default model: `llama-3.1-8b-instant`. Default user role: `"user"`.
 pub fn default_groq_request() -> GroqRequestBuilder {
   GroqRequestBuilder(
     key: "",
     user: "user",
     context: "",
-    model: "llama3-8b-8192",
+    model: "llama-3.1-8b-instant",
     frequency_penalty: Some(0.0),
-    logprobs: Some(False),
+    logprobs: None,
     max_tokens: None,
     n: Some(1),
     parallel_tool_calls: Some(True),
@@ -43,26 +57,44 @@ pub fn default_groq_request() -> GroqRequestBuilder {
     stream: Some(False),
     temperature: Some(1.0),
     top_p: Some(1.0),
+    system_prompt: None,
+    messages: [],
+    response_format: None,
   )
 }
 
-/// Create a new GroqRequestBuilder with no default values. 
+/// Creates a new `GroqRequestBuilder` with no preset values.
+/// You must set `key`, `model`, `user`, and `context` (or `messages`) before calling `build/1`.
 pub fn new_groq_request() -> GroqRequestBuilder {
   GroqRequestBuilder(
-    ..default_groq_request(),
     key: "",
     user: "",
     context: "",
     model: "",
+    frequency_penalty: None,
+    logprobs: None,
+    max_tokens: None,
+    n: None,
+    parallel_tool_calls: None,
+    presence_penalty: None,
+    seed: None,
+    stop: None,
+    stream: None,
+    temperature: None,
+    top_p: None,
+    system_prompt: None,
+    messages: [],
+    response_format: None,
   )
 }
 
-/// Sets the API key for the GroqRequestBuilder.
+/// Sets the GroqCloud API key.
 pub fn with_key(builder: GroqRequestBuilder, key: String) -> GroqRequestBuilder {
   GroqRequestBuilder(..builder, key: key)
 }
 
-/// Sets the user role for the GroqRequestBuilder.
+/// Sets the user role label for the single-turn message (default: `"user"`).
+/// For multi-turn conversations use `add_user_message/2` instead.
 pub fn with_user(
   builder: GroqRequestBuilder,
   user: String,
@@ -70,7 +102,8 @@ pub fn with_user(
   GroqRequestBuilder(..builder, user: user)
 }
 
-/// Sets the context/prompt for the GroqRequestBuilder.
+/// Sets the prompt text for a single-turn request.
+/// For multi-turn conversations use `add_user_message/2` instead.
 pub fn with_context(
   builder: GroqRequestBuilder,
   context: String,
@@ -78,7 +111,7 @@ pub fn with_context(
   GroqRequestBuilder(..builder, context: context)
 }
 
-/// Sets the model for the GroqRequestBuilder.
+/// Sets the model to use for inference. See `gloq/models` for available constants.
 pub fn with_model(
   builder: GroqRequestBuilder,
   model: String,
@@ -86,8 +119,53 @@ pub fn with_model(
   GroqRequestBuilder(..builder, model: model)
 }
 
-/// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency 
-/// in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+/// Sets a system prompt that is prepended as the first message.
+pub fn with_system_prompt(
+  builder: GroqRequestBuilder,
+  prompt: String,
+) -> GroqRequestBuilder {
+  GroqRequestBuilder(..builder, system_prompt: Some(prompt))
+}
+
+/// Replaces the entire conversation message list.
+/// When messages is non-empty, `with_user/2` and `with_context/2` are ignored.
+pub fn with_messages(
+  builder: GroqRequestBuilder,
+  messages: List(Message),
+) -> GroqRequestBuilder {
+  GroqRequestBuilder(..builder, messages: messages)
+}
+
+/// Appends a message with the given role and content to the conversation.
+pub fn add_message(
+  builder: GroqRequestBuilder,
+  role: String,
+  content: String,
+) -> GroqRequestBuilder {
+  GroqRequestBuilder(
+    ..builder,
+    messages: list.append(builder.messages, [Message(role: role, content: content)]),
+  )
+}
+
+/// Appends a user message to the conversation.
+pub fn add_user_message(
+  builder: GroqRequestBuilder,
+  content: String,
+) -> GroqRequestBuilder {
+  add_message(builder, "user", content)
+}
+
+/// Appends an assistant message to the conversation (useful for continuing a thread).
+pub fn add_assistant_message(
+  builder: GroqRequestBuilder,
+  content: String,
+) -> GroqRequestBuilder {
+  add_message(builder, "assistant", content)
+}
+
+/// Number between -2.0 and 2.0. Positive values penalize new tokens based on
+/// their existing frequency, decreasing the likelihood of repetition.
 pub fn with_frequency_penalty(
   builder: GroqRequestBuilder,
   frequency_penalty: Float,
@@ -95,8 +173,8 @@ pub fn with_frequency_penalty(
   GroqRequestBuilder(..builder, frequency_penalty: Some(frequency_penalty))
 }
 
-/// This is not yet supported by any of our models. Whether to return log probabilities of the output tokens or not.
-///  If true, returns the log probabilities of each output token returned in the `content` of `message`.
+/// Whether to return log probabilities of the output tokens.
+/// Not yet supported by all models.
 pub fn with_logprobs(
   builder: GroqRequestBuilder,
   logprobs: Bool,
@@ -104,8 +182,7 @@ pub fn with_logprobs(
   GroqRequestBuilder(..builder, logprobs: Some(logprobs))
 }
 
-/// The maximum number of tokens that can be generated in the chat completion. 
-/// The total length of input tokens and generated tokens is limited by the model's context length.
+/// Maximum number of tokens to generate. When `None` the model default is used.
 pub fn with_max_tokens(
   builder: GroqRequestBuilder,
   max_tokens: Int,
@@ -113,8 +190,7 @@ pub fn with_max_tokens(
   GroqRequestBuilder(..builder, max_tokens: Some(max_tokens))
 }
 
-/// How many chat completion choices to generate for each input message. 
-/// Note that the current moment, only n=1 is supported. Other values will result in a 400 response.
+/// Number of completion choices to generate. Only `n = 1` is currently supported.
 pub fn with_n(builder: GroqRequestBuilder, n: Int) -> GroqRequestBuilder {
   GroqRequestBuilder(..builder, n: Some(n))
 }
@@ -127,8 +203,8 @@ pub fn with_parallel_tool_calls(
   GroqRequestBuilder(..builder, parallel_tool_calls: Some(parallel_tool_calls))
 }
 
-/// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they
-///  appear in the text so far, increasing the model's likelihood to talk about new topics.
+/// Number between -2.0 and 2.0. Positive values penalize tokens that have
+/// already appeared, encouraging the model to discuss new topics.
 pub fn with_presence_penalty(
   builder: GroqRequestBuilder,
   presence_penalty: Float,
@@ -136,15 +212,14 @@ pub fn with_presence_penalty(
   GroqRequestBuilder(..builder, presence_penalty: Some(presence_penalty))
 }
 
-/// If specified, our system will make a best effort to sample deterministically, such that 
-/// repeated requests with the same seed and parameters should return the same result. 
-/// Determinism is not guaranteed, and you should refer to the system_fingerprint response 
-/// parameter to monitor changes in the backend.
+/// Setting a seed makes the system attempt to sample deterministically so that
+/// repeated requests with the same seed and parameters return the same result.
 pub fn with_seed(builder: GroqRequestBuilder, seed: Int) -> GroqRequestBuilder {
   GroqRequestBuilder(..builder, seed: Some(seed))
 }
 
-/// Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
+/// Up to 4 sequences where the API stops generating tokens. The stop sequence
+/// itself is not included in the output.
 pub fn with_stop(
   builder: GroqRequestBuilder,
   stop: String,
@@ -152,8 +227,7 @@ pub fn with_stop(
   GroqRequestBuilder(..builder, stop: Some(stop))
 }
 
-/// If set, partial message deltas will be sent. Tokens will be sent as data-only server-sent events as they become available, 
-/// with the stream terminated by a data: [DONE] message.
+/// When `True`, partial message deltas are sent as server-sent events.
 pub fn with_stream(
   builder: GroqRequestBuilder,
   stream: Bool,
@@ -161,8 +235,8 @@ pub fn with_stream(
   GroqRequestBuilder(..builder, stream: Some(stream))
 }
 
-/// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower 
-/// values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both
+/// Sampling temperature between 0 and 2. Higher values increase randomness;
+/// lower values increase focus. Do not use alongside `with_top_p/2`.
 pub fn with_temperature(
   builder: GroqRequestBuilder,
   temperature: Float,
@@ -170,8 +244,8 @@ pub fn with_temperature(
   GroqRequestBuilder(..builder, temperature: Some(temperature))
 }
 
-/// An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. 
-/// So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.
+/// Nucleus sampling threshold. The model considers only the top tokens whose
+/// cumulative probability exceeds this value. Do not use alongside `with_temperature/2`.
 pub fn with_top_p(
   builder: GroqRequestBuilder,
   top_p: Float,
@@ -179,45 +253,97 @@ pub fn with_top_p(
   GroqRequestBuilder(..builder, top_p: Some(top_p))
 }
 
-/// Builds the request body for the GroqCloud API that can be sent using the appropriate HTTP client.
-pub fn build(builder: GroqRequestBuilder) {
-  let body =
-    json.object([
-      #(
-        "messages",
-        json.array(
-          [
-            json.object([
-              #("role", json.string(builder.user)),
-              #("content", json.string(builder.context)),
-            ]),
-          ],
-          of: fn(x) { x },
-        ),
-      ),
-      #("model", json.string(builder.model)),
-      #(
-        "frequency_penalty",
-        json.float(option.unwrap(builder.frequency_penalty, 0.0)),
-      ),
-      #("logprobs", json.bool(option.unwrap(builder.logprobs, False))),
-      #("max_tokens", json.int(option.unwrap(builder.max_tokens, 8192))),
-      // 8192 is the largest accepted value for max_tokens accepted by the API
-      #("n", json.int(option.unwrap(builder.n, 1))),
-      #(
+/// Request a structured response format. Pass `"json_object"` to get valid JSON.
+/// When using this, instruct the model to produce JSON in your system prompt.
+pub fn with_response_format(
+  builder: GroqRequestBuilder,
+  format: String,
+) -> GroqRequestBuilder {
+  GroqRequestBuilder(..builder, response_format: Some(format))
+}
+
+fn optional_field(
+  key: String,
+  value: Option(a),
+  encoder: fn(a) -> Json,
+) -> Option(#(String, Json)) {
+  option.map(value, fn(v) { #(key, encoder(v)) })
+}
+
+/// Builds the HTTP request ready to send with your chosen HTTP client.
+/// Only optional fields that have been explicitly set are included in the body.
+///
+/// Example:
+/// ```gleam
+/// import gleam/httpc
+/// import gloq
+///
+/// let req =
+///   gloq.default_groq_request()
+///   |> gloq.with_key(api_key)
+///   |> gloq.with_context("Hello!")
+///   |> gloq.build()
+///
+/// let response = httpc.send(req)
+/// ```
+pub fn build(builder: GroqRequestBuilder) -> Request(String) {
+  let system_msgs = case builder.system_prompt {
+    None -> []
+    Some(prompt) -> [
+      json.object([
+        #("role", json.string("system")),
+        #("content", json.string(prompt)),
+      ]),
+    ]
+  }
+
+  let conversation_msgs = case builder.messages {
+    [] -> [
+      json.object([
+        #("role", json.string(builder.user)),
+        #("content", json.string(builder.context)),
+      ]),
+    ]
+    msgs ->
+      list.map(msgs, fn(m) {
+        json.object([
+          #("role", json.string(m.role)),
+          #("content", json.string(m.content)),
+        ])
+      })
+  }
+
+  let all_messages = list.append(system_msgs, conversation_msgs)
+
+  let optional_fields =
+    [
+      optional_field("frequency_penalty", builder.frequency_penalty, json.float),
+      optional_field("logprobs", builder.logprobs, json.bool),
+      optional_field("max_tokens", builder.max_tokens, json.int),
+      optional_field("n", builder.n, json.int),
+      optional_field(
         "parallel_tool_calls",
-        json.bool(option.unwrap(builder.parallel_tool_calls, True)),
+        builder.parallel_tool_calls,
+        json.bool,
       ),
-      #(
-        "presence_penalty",
-        json.float(option.unwrap(builder.presence_penalty, 0.0)),
-      ),
-      #("seed", json.int(option.unwrap(builder.seed, 0))),
-      #("stop", json.string(option.unwrap(builder.stop, ""))),
-      #("stream", json.bool(option.unwrap(builder.stream, False))),
-      #("temperature", json.float(option.unwrap(builder.temperature, 1.0))),
-      #("top_p", json.float(option.unwrap(builder.top_p, 1.0))),
-    ])
+      optional_field("presence_penalty", builder.presence_penalty, json.float),
+      optional_field("seed", builder.seed, json.int),
+      optional_field("stop", builder.stop, json.string),
+      optional_field("stream", builder.stream, json.bool),
+      optional_field("temperature", builder.temperature, json.float),
+      optional_field("top_p", builder.top_p, json.float),
+      optional_field("response_format", builder.response_format, fn(fmt) {
+        json.object([#("type", json.string(fmt))])
+      }),
+    ]
+    |> list.filter_map(fn(x) { x })
+
+  let required_fields = [
+    #("messages", json.array(all_messages, fn(x) { x })),
+    #("model", json.string(builder.model)),
+  ]
+
+  let body = json.object(list.append(required_fields, optional_fields))
 
   request.new()
   |> request.set_method(http.Post)
@@ -228,31 +354,44 @@ pub fn build(builder: GroqRequestBuilder) {
   |> request.set_body(json.to_string(body))
 }
 
-/// Sends the request to the GroqCloud API for chat completions.
-/// > [!Warning]
-/// > Function is deprecated, send logic is left to consumer
-/// To create a request, use the `build` function and send the request using the appropriate HTTP client of your choice.
-/// Uses the `hackney` HTTP client to send the request, this command is no longer supported.
+/// Builds a request to list all available models.
+///
+/// > Note: `view_models` is kept for backwards compatibility.
+/// > New code should prefer `list_models/1`.
+pub fn view_models(api_key: String) -> Request(String) {
+  list_models(api_key)
+}
+
+/// Builds a GET request to list all models available on your GroqCloud account.
+pub fn list_models(api_key: String) -> Request(String) {
+  request.new()
+  |> request.set_method(http.Get)
+  |> request.set_host("api.groq.com")
+  |> request.set_path("/openai/v1/models")
+  |> request.set_header("Authorization", "Bearer " <> api_key)
+  |> request.set_header("Content-Type", "application/json")
+}
+
+/// Builds a GET request to retrieve details for a single model by ID.
+pub fn get_model(api_key: String, model_id: String) -> Request(String) {
+  request.new()
+  |> request.set_method(http.Get)
+  |> request.set_host("api.groq.com")
+  |> request.set_path("/openai/v1/models/" <> model_id)
+  |> request.set_header("Authorization", "Bearer " <> api_key)
+  |> request.set_header("Content-Type", "application/json")
+}
+
+/// Sends the request to the GroqCloud API using the hackney HTTP client and
+/// returns the raw response body.
+///
+/// > **Deprecated** — send logic is intentionally left to the consumer so you
+/// > can use any HTTP client. Call `build/1` instead and send the request with
+/// > `gleam_httpc`, `gleam_hackney`, or your preferred client.
 pub fn send(builder: GroqRequestBuilder) -> String {
   let req = build(builder)
-
-  let res = hackney.send(req)
-
-  case res {
+  case hackney.send(req) {
     Ok(r) -> r.body
     Error(_) -> "Error, Request Failed"
   }
-}
-
-/// Builds the request body for the GroqCloud API that can be sent using the appropriate HTTP client.
-pub fn view_models(api_key: String) {
-  let request =
-    request.new()
-    |> request.set_method(http.Get)
-    |> request.set_host("api.groq.com")
-    |> request.set_path("/openai/v1/models")
-    |> request.set_header("Authorization", "Bearer " <> api_key)
-    |> request.set_header("Content-Type", "application/json")
-
-  request
 }

--- a/src/gloq.gleam
+++ b/src/gloq.gleam
@@ -336,7 +336,7 @@ pub fn build(builder: GroqRequestBuilder) -> Request(String) {
         json.object([#("type", json.string(fmt))])
       }),
     ]
-    |> list.filter_map(fn(x) { x })
+    |> list.filter_map(fn(x) { option.to_result(x, Nil) })
 
   let required_fields = [
     #("messages", json.array(all_messages, fn(x) { x })),

--- a/src/gloq/models.gleam
+++ b/src/gloq/models.gleam
@@ -1,0 +1,75 @@
+/// Constants for all currently available GroqCloud models.
+/// Use these instead of raw strings to avoid typos and get IDE completion.
+///
+/// Example:
+/// ```gleam
+/// import gloq
+/// import gloq/models
+///
+/// gloq.default_groq_request()
+/// |> gloq.with_key(api_key)
+/// |> gloq.with_model(models.llama_3_1_8b_instant)
+/// |> gloq.with_context("Hello!")
+/// |> gloq.build()
+/// ```
+
+// ── Llama 3.3 ──────────────────────────────────────────────────────────────
+
+/// Llama 3.3 70B — latest generation, 128k context. Recommended default.
+pub const llama_3_3_70b_versatile = "llama-3.3-70b-versatile"
+
+/// Llama 3.3 70B with speculative decoding for faster output.
+pub const llama_3_3_70b_specdec = "llama-3.3-70b-specdec"
+
+// ── Llama 3.1 ──────────────────────────────────────────────────────────────
+
+/// Llama 3.1 8B — fast, lightweight, 128k context. Good for high-throughput.
+pub const llama_3_1_8b_instant = "llama-3.1-8b-instant"
+
+/// Llama 3.1 70B — powerful, 128k context.
+pub const llama_3_1_70b_versatile = "llama-3.1-70b-versatile"
+
+// ── Llama 3.2 ──────────────────────────────────────────────────────────────
+
+/// Llama 3.2 1B — ultra-lightweight model for edge use cases.
+pub const llama_3_2_1b_preview = "llama-3.2-1b-preview"
+
+/// Llama 3.2 3B — small but capable.
+pub const llama_3_2_3b_preview = "llama-3.2-3b-preview"
+
+/// Llama 3.2 11B Vision — multimodal model supporting image inputs.
+pub const llama_3_2_11b_vision_preview = "llama-3.2-11b-vision-preview"
+
+/// Llama 3.2 90B Vision — large multimodal model.
+pub const llama_3_2_90b_vision_preview = "llama-3.2-90b-vision-preview"
+
+// ── Llama 3 (legacy) ───────────────────────────────────────────────────────
+
+/// Llama 3 8B — legacy model, 8k context. Prefer llama_3_1_8b_instant.
+pub const llama3_8b_8192 = "llama3-8b-8192"
+
+/// Llama 3 70B — legacy model, 8k context. Prefer llama_3_1_70b_versatile.
+pub const llama3_70b_8192 = "llama3-70b-8192"
+
+// ── Mixtral ────────────────────────────────────────────────────────────────
+
+/// Mixtral 8x7B MoE — 32k context. Strong at reasoning and code.
+pub const mixtral_8x7b_32768 = "mixtral-8x7b-32768"
+
+// ── Gemma ──────────────────────────────────────────────────────────────────
+
+/// Gemma 2 9B — Google's efficient instruction-tuned model.
+pub const gemma2_9b_it = "gemma2-9b-it"
+
+/// Gemma 7B — legacy Google model. Prefer gemma2_9b_it.
+pub const gemma_7b_it = "gemma-7b-it"
+
+// ── DeepSeek ───────────────────────────────────────────────────────────────
+
+/// DeepSeek R1 distilled on Llama 70B — strong reasoning model.
+pub const deepseek_r1_distill_llama_70b = "deepseek-r1-distill-llama-70b"
+
+// ── Qwen ───────────────────────────────────────────────────────────────────
+
+/// Qwen QwQ 32B — strong reasoning and long-context model.
+pub const qwen_qwq_32b = "qwen-qwq-32b"

--- a/src/gloq/models.gleam
+++ b/src/gloq/models.gleam
@@ -1,17 +1,15 @@
-/// Constants for all currently available GroqCloud models.
-/// Use these instead of raw strings to avoid typos and get IDE completion.
-///
-/// Example:
-/// ```gleam
-/// import gloq
-/// import gloq/models
-///
-/// gloq.default_groq_request()
-/// |> gloq.with_key(api_key)
-/// |> gloq.with_model(models.llama_3_1_8b_instant)
-/// |> gloq.with_context("Hello!")
-/// |> gloq.build()
-/// ```
+// Constants for all currently available GroqCloud models.
+// Use these instead of raw strings to avoid typos and get IDE completion.
+//
+// Example:
+//   import gloq
+//   import gloq/models
+//
+//   gloq.default_groq_request()
+//   |> gloq.with_key(api_key)
+//   |> gloq.with_model(models.llama_3_1_8b_instant)
+//   |> gloq.with_context("Hello!")
+//   |> gloq.build()
 
 // ── Llama 3.3 ──────────────────────────────────────────────────────────────
 

--- a/src/gloq/response.gleam
+++ b/src/gloq/response.gleam
@@ -119,15 +119,18 @@ fn api_error_decoder() -> decode.Decoder(ApiError) {
 /// Decode a JSON response string into a `ChatCompletion`.
 /// Returns an error if the JSON is malformed or missing required fields.
 pub fn decode(json_string: String) -> Result(ChatCompletion, json.DecodeError) {
-  json.decode(json_string, chat_completion_decoder())
+  json.parse(json_string, chat_completion_decoder())
+}
+
+fn outer_error_decoder() -> decode.Decoder(ApiError) {
+  use error <- decode.field("error", api_error_decoder())
+  decode.success(error)
 }
 
 /// Decode an API error response. Use this when `decode` fails to check
 /// whether the server returned a structured error object.
 pub fn decode_error(json_string: String) -> Result(ApiError, json.DecodeError) {
-  use outer <- decode.field("error", api_error_decoder())
-  decode.success(outer)
-  |> json.decode(json_string, _)
+  json.parse(json_string, outer_error_decoder())
 }
 
 /// Extract the text content from the first choice in a completion.

--- a/src/gloq/response.gleam
+++ b/src/gloq/response.gleam
@@ -1,0 +1,145 @@
+/// Types and decoders for GroqCloud chat completion responses.
+///
+/// Example:
+/// ```gleam
+/// import gleam/httpc
+/// import gloq
+/// import gloq/response
+///
+/// let req =
+///   gloq.default_groq_request()
+///   |> gloq.with_key(api_key)
+///   |> gloq.with_context("What is 2+2?")
+///   |> gloq.build()
+///
+/// case httpc.send(req) {
+///   Ok(res) ->
+///     case response.decode(res.body) {
+///       Ok(completion) -> io.println(response.content(completion))
+///       Error(_) -> io.println("Failed to decode response")
+///     }
+///   Error(_) -> io.println("Request failed")
+/// }
+/// ```
+
+import gleam/dynamic/decode
+import gleam/json
+import gleam/list
+import gleam/option.{type Option}
+
+/// Token usage statistics returned with every completion.
+pub type Usage {
+  Usage(
+    prompt_tokens: Int,
+    completion_tokens: Int,
+    total_tokens: Int,
+  )
+}
+
+/// The assistant message returned in a completion choice.
+pub type ResponseMessage {
+  ResponseMessage(role: String, content: String)
+}
+
+/// A single completion choice. Most requests return exactly one choice.
+pub type Choice {
+  Choice(
+    index: Int,
+    message: ResponseMessage,
+    finish_reason: Option(String),
+  )
+}
+
+/// A full chat completion response from the GroqCloud API.
+pub type ChatCompletion {
+  ChatCompletion(
+    id: String,
+    model: String,
+    choices: List(Choice),
+    usage: Usage,
+  )
+}
+
+/// An error response from the GroqCloud API.
+pub type ApiError {
+  ApiError(message: String, error_type: String, code: Option(String))
+}
+
+fn usage_decoder() -> decode.Decoder(Usage) {
+  use prompt_tokens <- decode.field("prompt_tokens", decode.int)
+  use completion_tokens <- decode.field("completion_tokens", decode.int)
+  use total_tokens <- decode.field("total_tokens", decode.int)
+  decode.success(Usage(
+    prompt_tokens: prompt_tokens,
+    completion_tokens: completion_tokens,
+    total_tokens: total_tokens,
+  ))
+}
+
+fn response_message_decoder() -> decode.Decoder(ResponseMessage) {
+  use role <- decode.field("role", decode.string)
+  use content <- decode.field("content", decode.string)
+  decode.success(ResponseMessage(role: role, content: content))
+}
+
+fn choice_decoder() -> decode.Decoder(Choice) {
+  use index <- decode.field("index", decode.int)
+  use message <- decode.field("message", response_message_decoder())
+  use finish_reason <- decode.field(
+    "finish_reason",
+    decode.optional(decode.string),
+  )
+  decode.success(Choice(
+    index: index,
+    message: message,
+    finish_reason: finish_reason,
+  ))
+}
+
+fn chat_completion_decoder() -> decode.Decoder(ChatCompletion) {
+  use id <- decode.field("id", decode.string)
+  use model <- decode.field("model", decode.string)
+  use choices <- decode.field("choices", decode.list(choice_decoder()))
+  use usage <- decode.field("usage", usage_decoder())
+  decode.success(ChatCompletion(
+    id: id,
+    model: model,
+    choices: choices,
+    usage: usage,
+  ))
+}
+
+fn api_error_decoder() -> decode.Decoder(ApiError) {
+  use message <- decode.field("message", decode.string)
+  use error_type <- decode.field("type", decode.string)
+  use code <- decode.field("code", decode.optional(decode.string))
+  decode.success(ApiError(message: message, error_type: error_type, code: code))
+}
+
+/// Decode a JSON response string into a `ChatCompletion`.
+/// Returns an error if the JSON is malformed or missing required fields.
+pub fn decode(json_string: String) -> Result(ChatCompletion, json.DecodeError) {
+  json.decode(json_string, chat_completion_decoder())
+}
+
+/// Decode an API error response. Use this when `decode` fails to check
+/// whether the server returned a structured error object.
+pub fn decode_error(json_string: String) -> Result(ApiError, json.DecodeError) {
+  use outer <- decode.field("error", api_error_decoder())
+  decode.success(outer)
+  |> json.decode(json_string, _)
+}
+
+/// Extract the text content from the first choice in a completion.
+/// Returns an empty string if there are no choices.
+pub fn content(completion: ChatCompletion) -> String {
+  case completion.choices {
+    [] -> ""
+    [choice, ..] -> choice.message.content
+  }
+}
+
+/// Extract text content from all choices in a completion.
+pub fn all_contents(completion: ChatCompletion) -> List(String) {
+  list.map(completion.choices, fn(c) { c.message.content })
+}

--- a/test/gloq_test.gleam
+++ b/test/gloq_test.gleam
@@ -1,17 +1,26 @@
 import gleeunit
 import gleeunit/should
+import gleam/http
+import gleam/http/request
+import gleam/option.{None, Some}
+import gleam/string
 import gloq
 
 pub fn main() {
   gleeunit.main()
 }
 
+// ── Builder initialisation ──────────────────────────────────────────────────
+
 pub fn default_groq_request_test() {
   let builder = gloq.default_groq_request()
   builder.key |> should.equal("")
   builder.user |> should.equal("user")
   builder.context |> should.equal("")
-  builder.model |> should.equal("llama3-8b-8192")
+  builder.model |> should.equal("llama-3.1-8b-instant")
+  builder.system_prompt |> should.equal(None)
+  builder.messages |> should.equal([])
+  builder.response_format |> should.equal(None)
 }
 
 pub fn new_groq_request_test() {
@@ -20,27 +29,306 @@ pub fn new_groq_request_test() {
   builder.user |> should.equal("")
   builder.context |> should.equal("")
   builder.model |> should.equal("")
+  builder.frequency_penalty |> should.equal(None)
+  builder.temperature |> should.equal(None)
+  builder.max_tokens |> should.equal(None)
+  builder.seed |> should.equal(None)
+  builder.messages |> should.equal([])
 }
 
+// ── Core setters ────────────────────────────────────────────────────────────
+
 pub fn with_key_test() {
-  let builder = gloq.new_groq_request() |> gloq.with_key("test_key")
-  builder.key |> should.equal("test_key")
+  gloq.new_groq_request()
+  |> gloq.with_key("sk-test")
+  |> fn(b) { b.key }
+  |> should.equal("sk-test")
 }
 
 pub fn with_user_test() {
-  let builder = gloq.new_groq_request() |> gloq.with_user("test_user")
-  builder.user |> should.equal("test_user")
+  gloq.new_groq_request()
+  |> gloq.with_user("assistant")
+  |> fn(b) { b.user }
+  |> should.equal("assistant")
 }
 
 pub fn with_context_test() {
-  let builder = gloq.new_groq_request() |> gloq.with_context("test_context")
-  builder.context |> should.equal("test_context")
+  gloq.new_groq_request()
+  |> gloq.with_context("Hello, world!")
+  |> fn(b) { b.context }
+  |> should.equal("Hello, world!")
 }
 
 pub fn with_model_test() {
-  let builder = gloq.new_groq_request() |> gloq.with_model("test_model")
-  builder.model |> should.equal("test_model")
+  gloq.new_groq_request()
+  |> gloq.with_model("llama-3.3-70b-versatile")
+  |> fn(b) { b.model }
+  |> should.equal("llama-3.3-70b-versatile")
 }
+
+// ── Optional parameter setters ──────────────────────────────────────────────
+
+pub fn with_temperature_test() {
+  gloq.new_groq_request()
+  |> gloq.with_temperature(0.7)
+  |> fn(b) { b.temperature }
+  |> should.equal(Some(0.7))
+}
+
+pub fn with_max_tokens_test() {
+  gloq.new_groq_request()
+  |> gloq.with_max_tokens(512)
+  |> fn(b) { b.max_tokens }
+  |> should.equal(Some(512))
+}
+
+pub fn with_frequency_penalty_test() {
+  gloq.new_groq_request()
+  |> gloq.with_frequency_penalty(0.5)
+  |> fn(b) { b.frequency_penalty }
+  |> should.equal(Some(0.5))
+}
+
+pub fn with_presence_penalty_test() {
+  gloq.new_groq_request()
+  |> gloq.with_presence_penalty(-0.5)
+  |> fn(b) { b.presence_penalty }
+  |> should.equal(Some(-0.5))
+}
+
+pub fn with_top_p_test() {
+  gloq.new_groq_request()
+  |> gloq.with_top_p(0.9)
+  |> fn(b) { b.top_p }
+  |> should.equal(Some(0.9))
+}
+
+pub fn with_seed_test() {
+  gloq.new_groq_request()
+  |> gloq.with_seed(42)
+  |> fn(b) { b.seed }
+  |> should.equal(Some(42))
+}
+
+pub fn with_stop_test() {
+  gloq.new_groq_request()
+  |> gloq.with_stop("\n")
+  |> fn(b) { b.stop }
+  |> should.equal(Some("\n"))
+}
+
+pub fn with_stream_test() {
+  gloq.new_groq_request()
+  |> gloq.with_stream(True)
+  |> fn(b) { b.stream }
+  |> should.equal(Some(True))
+}
+
+pub fn with_n_test() {
+  gloq.new_groq_request()
+  |> gloq.with_n(1)
+  |> fn(b) { b.n }
+  |> should.equal(Some(1))
+}
+
+pub fn with_logprobs_test() {
+  gloq.new_groq_request()
+  |> gloq.with_logprobs(True)
+  |> fn(b) { b.logprobs }
+  |> should.equal(Some(True))
+}
+
+pub fn with_parallel_tool_calls_test() {
+  gloq.new_groq_request()
+  |> gloq.with_parallel_tool_calls(False)
+  |> fn(b) { b.parallel_tool_calls }
+  |> should.equal(Some(False))
+}
+
+// ── New v2 features ─────────────────────────────────────────────────────────
+
+pub fn with_system_prompt_test() {
+  gloq.new_groq_request()
+  |> gloq.with_system_prompt("You are a helpful assistant.")
+  |> fn(b) { b.system_prompt }
+  |> should.equal(Some("You are a helpful assistant."))
+}
+
+pub fn with_response_format_test() {
+  gloq.new_groq_request()
+  |> gloq.with_response_format("json_object")
+  |> fn(b) { b.response_format }
+  |> should.equal(Some("json_object"))
+}
+
+pub fn add_user_message_test() {
+  let builder =
+    gloq.new_groq_request()
+    |> gloq.add_user_message("Hello!")
+  builder.messages |> should.equal([gloq.Message(role: "user", content: "Hello!")])
+}
+
+pub fn add_assistant_message_test() {
+  let builder =
+    gloq.new_groq_request()
+    |> gloq.add_assistant_message("Hi there!")
+  builder.messages
+  |> should.equal([gloq.Message(role: "assistant", content: "Hi there!")])
+}
+
+pub fn multi_turn_messages_test() {
+  let builder =
+    gloq.new_groq_request()
+    |> gloq.add_user_message("What is 2+2?")
+    |> gloq.add_assistant_message("4")
+    |> gloq.add_user_message("And 3+3?")
+
+  builder.messages
+  |> should.equal([
+    gloq.Message(role: "user", content: "What is 2+2?"),
+    gloq.Message(role: "assistant", content: "4"),
+    gloq.Message(role: "user", content: "And 3+3?"),
+  ])
+}
+
+pub fn with_messages_replaces_list_test() {
+  let msgs = [
+    gloq.Message(role: "user", content: "Hi"),
+    gloq.Message(role: "assistant", content: "Hello"),
+  ]
+  gloq.new_groq_request()
+  |> gloq.add_user_message("ignored")
+  |> gloq.with_messages(msgs)
+  |> fn(b) { b.messages }
+  |> should.equal(msgs)
+}
+
+// ── Build output ─────────────────────────────────────────────────────────────
+
+pub fn build_method_test() {
+  let req =
+    gloq.default_groq_request()
+    |> gloq.with_key("test-key")
+    |> gloq.with_context("hi")
+    |> gloq.build()
+  req.method |> should.equal(http.Post)
+}
+
+pub fn build_host_test() {
+  let req =
+    gloq.default_groq_request()
+    |> gloq.with_key("test-key")
+    |> gloq.with_context("hi")
+    |> gloq.build()
+  req.host |> should.equal("api.groq.com")
+}
+
+pub fn build_path_test() {
+  let req =
+    gloq.default_groq_request()
+    |> gloq.with_key("test-key")
+    |> gloq.with_context("hi")
+    |> gloq.build()
+  req.path |> should.equal("/openai/v1/chat/completions")
+}
+
+pub fn build_auth_header_test() {
+  let req =
+    gloq.default_groq_request()
+    |> gloq.with_key("my-api-key")
+    |> gloq.with_context("hi")
+    |> gloq.build()
+  request.get_header(req, "authorization")
+  |> should.equal(Ok("Bearer my-api-key"))
+}
+
+pub fn build_content_type_header_test() {
+  let req =
+    gloq.default_groq_request()
+    |> gloq.with_key("test-key")
+    |> gloq.with_context("hi")
+    |> gloq.build()
+  request.get_header(req, "content-type")
+  |> should.equal(Ok("application/json"))
+}
+
+pub fn build_body_contains_model_test() {
+  let req =
+    gloq.default_groq_request()
+    |> gloq.with_key("test-key")
+    |> gloq.with_model("llama-3.3-70b-versatile")
+    |> gloq.with_context("hi")
+    |> gloq.build()
+  req.body |> string.contains("llama-3.3-70b-versatile") |> should.equal(True)
+}
+
+pub fn build_body_contains_messages_test() {
+  let req =
+    gloq.default_groq_request()
+    |> gloq.with_key("test-key")
+    |> gloq.with_context("hello from test")
+    |> gloq.build()
+  req.body |> string.contains("messages") |> should.equal(True)
+  req.body |> string.contains("hello from test") |> should.equal(True)
+}
+
+pub fn build_omits_none_fields_test() {
+  let req =
+    gloq.new_groq_request()
+    |> gloq.with_key("test-key")
+    |> gloq.with_model("llama-3.1-8b-instant")
+    |> gloq.with_context("hi")
+    |> gloq.build()
+  // seed, stop, max_tokens were not set — must not appear in body
+  req.body |> string.contains("\"seed\"") |> should.equal(False)
+  req.body |> string.contains("\"stop\"") |> should.equal(False)
+  req.body |> string.contains("\"max_tokens\"") |> should.equal(False)
+}
+
+pub fn build_system_prompt_in_messages_test() {
+  let req =
+    gloq.default_groq_request()
+    |> gloq.with_key("test-key")
+    |> gloq.with_system_prompt("You are concise.")
+    |> gloq.with_context("hi")
+    |> gloq.build()
+  req.body |> string.contains("system") |> should.equal(True)
+  req.body |> string.contains("You are concise.") |> should.equal(True)
+}
+
+pub fn build_response_format_test() {
+  let req =
+    gloq.default_groq_request()
+    |> gloq.with_key("test-key")
+    |> gloq.with_context("give me json")
+    |> gloq.with_response_format("json_object")
+    |> gloq.build()
+  req.body |> string.contains("response_format") |> should.equal(True)
+  req.body |> string.contains("json_object") |> should.equal(True)
+}
+
+// ── Model listing requests ───────────────────────────────────────────────────
+
+pub fn list_models_method_test() {
+  let req = gloq.list_models("test-key")
+  req.method |> should.equal(http.Get)
+  req.path |> should.equal("/openai/v1/models")
+}
+
+pub fn get_model_path_test() {
+  let req = gloq.get_model("test-key", "llama-3.1-8b-instant")
+  req.method |> should.equal(http.Get)
+  req.path |> should.equal("/openai/v1/models/llama-3.1-8b-instant")
+}
+
+pub fn view_models_backwards_compat_test() {
+  let a = gloq.view_models("key")
+  let b = gloq.list_models("key")
+  a.path |> should.equal(b.path)
+  a.method |> should.equal(b.method)
+}
+
+// ── Legacy chained builder ───────────────────────────────────────────────────
 
 pub fn chained_builder_test() {
   let builder =


### PR DESCRIPTION
## Summary

- `gloq/models` — typed constants for all current GroqCloud models
- `gloq/response` — ChatCompletion/Choice/Usage/ApiError types with JSON decoder
- Multi-turn: add_user_message, add_assistant_message, with_system_prompt
- Structured output: with_response_format (json_object)
- Model listing: list_models, get_model; view_models kept as alias
- JSON fix: None optional fields no longer sent with wrong defaults
- Default model updated to llama-3.1-8b-instant
- Deps cleaned: removed dot_env, dotenv, gleam_httpc; stdlib ~> 1.0
- CI: checkout@v4, OTP 27.2, Gleam 1.6.0
- Tests: 7 → 30+

## Breaking changes

See README migration guide.

## Test plan

- [ ] CI passes (gleam test + gleam format --check)
- [ ] gleam deps download resolves on fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)