### PR TITLE
Bump to v2.0.1 and add Hex publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27.2"
+          gleam-version: "1.16.0"
+          rebar3-version: "3"
+      - run: gleam deps download
+      - run: gleam publish --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gloq"
-version = "2.0.0"
+version = "2.0.1"
 
 description = "Gleam API Wrapper to Interface with the GroqCloud API"
 licences = ["Apache-2.0"]


### PR DESCRIPTION
## Summary

- Bump version from `2.0.0` to `2.0.1` in `gleam.toml` so the updated README documentation propagates to HexDocs (Hex PM doesn't allow republishing the same version)
- Add `.github/workflows/publish.yml` — triggers on `v*` tags or manual dispatch, runs `gleam publish --yes` using `HEX_API_KEY` from GitHub Actions secrets

## To publish

1. Add `HEX_API_KEY` as a GitHub Actions secret (Settings → Secrets → Actions) if not already set
2. Merge this PR into `main`
3. Either:
   - **Tag-based**: `git tag v2.0.1 && git push origin v2.0.1` — workflow fires automatically
   - **Manual**: Go to Actions → publish → Run workflow

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFxnLEWXmLUqpkGeYn9CfW)_